### PR TITLE
[Core-230] add validations to json-schemas in some schema forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/pre_commit_hooks/check_json_schemas.py
+++ b/pre_commit_hooks/check_json_schemas.py
@@ -4,48 +4,61 @@ import argparse
 import json
 from typing import Sequence
 
-from jsonschema.validators import Draft7Validator, Draft3Validator, Draft4Validator, Draft6Validator, \
-    Draft201909Validator, Draft202012Validator
+from jsonschema.validators import (
+    Draft7Validator,
+    Draft3Validator,
+    Draft4Validator,
+    Draft6Validator,
+    Draft201909Validator,
+    Draft202012Validator,
+)
 from jsonschema.exceptions import SchemaError
 
-SCHEMA = '$schema'
+SCHEMA = "$schema"
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     retval = 0
     parser = argparse.ArgumentParser()
-    parser.add_argument('filenames', nargs='*', help='Filenames to check.')
+    parser.add_argument("filenames", nargs="*", help="Filenames to check.")
     args = parser.parse_args(argv)
 
     for filename in args.filenames:
         try:
-            with open(filename, 'rb') as f:
+            with open(filename, "rb") as f:
                 schema = json.load(f)
-
                 if SCHEMA not in schema:
-                    print(f'{filename}: invalid schema, because there is not an entry with $schema in json file')
+                    print(
+                        f"{filename}: invalid schema, because there is not an entry with $schema in json file"
+                    )
                     retval = 1
                     continue
-
-                if Draft3Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                schemaRef = schema.get(SCHEMA)
+                # we are not using the match statement here because we want to support python 3.6
+                if Draft3Validator.META_SCHEMA[SCHEMA] in schemaRef:
                     Draft3Validator.check_schema(schema)
-                elif Draft4Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                elif Draft4Validator.META_SCHEMA[SCHEMA] in schemaRef:
                     Draft4Validator.check_schema(schema)
-                elif Draft6Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                elif Draft6Validator.META_SCHEMA[SCHEMA] in schemaRef:
                     Draft6Validator.check_schema(schema)
-                elif Draft201909Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                elif Draft201909Validator.META_SCHEMA[SCHEMA] in schemaRef:
                     Draft201909Validator.check_schema(schema)
-                elif Draft202012Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                elif Draft202012Validator.META_SCHEMA[SCHEMA] in schemaRef:
                     Draft202012Validator.check_schema(schema)
-                elif Draft7Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                elif Draft7Validator.META_SCHEMA[SCHEMA] in schemaRef:
                     Draft7Validator.check_schema(schema)
+                else:
+                    print(
+                        f"{filename}: invalid json schema version set in $schema attribute: {schemaRef}"
+                    )
+                    retval = 1
 
         except SchemaError as e:
-            print(f'{filename}: invalid schema: {e}')
+            print(f"{filename}: invalid schema: {e}")
             retval = 1
 
     return retval
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/pre_commit_hooks/check_json_schemas.py
+++ b/pre_commit_hooks/check_json_schemas.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
-from typing import Sequence
+
 import argparse
 import json
-from fastjsonschema import compile, JsonSchemaDefinitionException, JsonSchemaException
+from typing import Sequence
+
+from jsonschema.validators import Draft7Validator, Draft3Validator, Draft4Validator, Draft6Validator, \
+    Draft201909Validator, Draft202012Validator
+from jsonschema.exceptions import SchemaError
+
+SCHEMA = '$schema'
+
 
 def main(argv: Sequence[str] | None = None) -> int:
     retval = 0
@@ -14,13 +21,31 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             with open(filename, 'rb') as f:
                 schema = json.load(f)
-                compile(schema)
-        except JsonSchemaDefinitionException as e:
+
+                if SCHEMA not in schema:
+                    print(f'{filename}: invalid schema, because there is not an entry with $schema in json file')
+                    retval = 1
+                    continue
+
+                if Draft3Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                    Draft3Validator.check_schema(schema)
+                elif Draft4Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                    Draft4Validator.check_schema(schema)
+                elif Draft6Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                    Draft6Validator.check_schema(schema)
+                elif Draft201909Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                    Draft201909Validator.check_schema(schema)
+                elif Draft202012Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                    Draft202012Validator.check_schema(schema)
+                elif Draft7Validator.META_SCHEMA[SCHEMA] in schema.get(SCHEMA):
+                    Draft7Validator.check_schema(schema)
+
+        except SchemaError as e:
             print(f'{filename}: invalid schema: {e}')
             retval = 1
-        except JsonSchemaException:
-            None
+
     return retval
+
 
 if __name__ == '__main__':
     raise SystemExit(main())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 covdefaults
 coverage
 pytest
+jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest~=8.2.0
+setuptools~=68.2.0
+jsonschema~=4.22.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ long_description = file: README.md
 [options]
 packages = find:
 install_requires =
-    fastjsonschema >= 2.17.1
+    jsonschema >= 4.22.0
 
 python_requires = >=3.7
 

--- a/tests/check_json_schemas_test.py
+++ b/tests/check_json_schemas_test.py
@@ -3,23 +3,23 @@ from pre_commit_hooks.check_json_schemas import main
 
 def test_valid_schemas(valid_set_of_files):
     for arg in valid_set_of_files:
-        print(f': [test_valid_schemas] assert if {arg} is a valid schema-file')
+        print(f": [test_valid_schemas] assert if {arg} is a valid schema-file")
         assert main([arg]) == 0
 
 
 def test_all_valid_schema_files(valid_set_of_files):
-    print(f': [test_all_valid_schema_files] assert if all schema-files are valid')
+    print(": [test_all_valid_schema_files] assert if all schema-files are valid")
     args = valid_set_of_files
     assert main(args) == 0
 
 
 def test_invalid_schemas(invalid_set_of_files):
     for arg in invalid_set_of_files:
-        print(f': [test_invalid_schemas] assert if {arg} is a invalid schema-file')
+        print(f": [test_invalid_schemas] assert if {arg} is a invalid schema-file")
         assert main([arg]) == 1
 
 
 def test_all_invalid_schemas(invalid_set_of_files):
-    print(f': [test_all_invalid_schemas] assert if all schema-files are invalid')
+    print(": [test_all_invalid_schemas] assert if all schema-files are invalid")
     args = invalid_set_of_files
     assert main(args) == 1

--- a/tests/check_json_schemas_test.py
+++ b/tests/check_json_schemas_test.py
@@ -1,12 +1,25 @@
-import pytest
 from pre_commit_hooks.check_json_schemas import main
 
 
 def test_valid_schemas(valid_set_of_files):
+    for arg in valid_set_of_files:
+        print(f': [test_valid_schemas] assert if {arg} is a valid schema-file')
+        assert main([arg]) == 0
+
+
+def test_all_valid_schema_files(valid_set_of_files):
+    print(f': [test_all_valid_schema_files] assert if all schema-files are valid')
     args = valid_set_of_files
     assert main(args) == 0
 
+
 def test_invalid_schemas(invalid_set_of_files):
+    for arg in invalid_set_of_files:
+        print(f': [test_invalid_schemas] assert if {arg} is a invalid schema-file')
+        assert main([arg]) == 1
+
+
+def test_all_invalid_schemas(invalid_set_of_files):
+    print(f': [test_all_invalid_schemas] assert if all schema-files are invalid')
     args = invalid_set_of_files
     assert main(args) == 1
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,26 +1,36 @@
+import os
+from pathlib import Path
 import pytest
 
 
 @pytest.fixture
-def valid_set_of_files():
+def valid_set_of_files(request: pytest.FixtureRequest):
+    folder = Path(os.path.dirname(request.path))
     return [
-        "fixtures/valid-schemas/draft-03.json",
-        "fixtures/valid-schemas/draft-04.json",
-        "fixtures/valid-schemas/draft-06.json",
-        "fixtures/valid-schemas/draft-07.json",
-        "fixtures/valid-schemas/draft-201909.json",
-        "fixtures/valid-schemas/draft-202012.json",
+        item.as_posix()
+        for item in [
+            folder / "fixtures/valid-schemas/draft-03.json",
+            folder / "fixtures/valid-schemas/draft-04.json",
+            folder / "fixtures/valid-schemas/draft-06.json",
+            folder / "fixtures/valid-schemas/draft-07.json",
+            folder / "fixtures/valid-schemas/draft-201909.json",
+            folder / "fixtures/valid-schemas/draft-202012.json",
+        ]
     ]
 
 
 @pytest.fixture
-def invalid_set_of_files():
+def invalid_set_of_files(request: pytest.FixtureRequest):
+    folder = Path(os.path.dirname(request.path))
     return [
-        "fixtures/invalid-schemas/without-schema-entry.json",
-        "fixtures/invalid-schemas/draft-03.json",
-        "fixtures/invalid-schemas/draft-04.json",
-        "fixtures/invalid-schemas/draft-06.json",
-        "fixtures/invalid-schemas/draft-07.json",
-        "fixtures/invalid-schemas/draft-201909.json",
-        "fixtures/invalid-schemas/draft-202012.json",
+        item.as_posix()
+        for item in [
+            folder / "fixtures/invalid-schemas/without-schema-entry.json",
+            folder / "fixtures/invalid-schemas/draft-03.json",
+            folder / "fixtures/invalid-schemas/draft-04.json",
+            folder / "fixtures/invalid-schemas/draft-06.json",
+            folder / "fixtures/invalid-schemas/draft-07.json",
+            folder / "fixtures/invalid-schemas/draft-201909.json",
+            folder / "fixtures/invalid-schemas/draft-202012.json",
+        ]
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,26 @@
 import pytest
 
-@pytest.fixture
-def build_content(tmp_path):
-    def inner(contents):
-        files = []
-        count = 0
-        for content in contents:
-            f = tmp_path/ str(count)
-            f.write_text(content)
-            files.append(str(f))
-            count = count + 1
-        return files
-    return inner
 
 @pytest.fixture
-def valid_set_of_files(build_content):
-    return build_content(["""{"format": "date-time"}""", """{"format": "date"}"""])
+def valid_set_of_files():
+    return [
+        "fixtures/valid-schemas/draft-03.json",
+        "fixtures/valid-schemas/draft-04.json",
+        "fixtures/valid-schemas/draft-06.json",
+        "fixtures/valid-schemas/draft-07.json",
+        "fixtures/valid-schemas/draft-201909.json",
+        "fixtures/valid-schemas/draft-202012.json",
+    ]
 
 
 @pytest.fixture
-def invalid_set_of_files(build_content):
-    return build_content(["""{"format": "invalid="}"""])
+def invalid_set_of_files():
+    return [
+        "fixtures/invalid-schemas/without-schema-entry.json",
+        "fixtures/invalid-schemas/draft-03.json",
+        "fixtures/invalid-schemas/draft-04.json",
+        "fixtures/invalid-schemas/draft-06.json",
+        "fixtures/invalid-schemas/draft-07.json",
+        "fixtures/invalid-schemas/draft-201909.json",
+        "fixtures/invalid-schemas/draft-202012.json",
+    ]

--- a/tests/fixtures/invalid-schemas/draft-03.json
+++ b/tests/fixtures/invalid-schemas/draft-03.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "id": "http://jsonschema.net",
+  "type": "object",
+  "properties": {
+    "title": {
+      "id": "http://jsonschema.net/title",
+      "type": "string"
+    }
+  },
+  "required": [
+    "title"
+  ]
+}

--- a/tests/fixtures/invalid-schemas/draft-04.json
+++ b/tests/fixtures/invalid-schemas/draft-04.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://jsonschema.net",
+  "type": "any",
+  "properties": {
+    "title": {
+      "id": "http://jsonschema.net/title",
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/tests/fixtures/invalid-schemas/draft-06.json
+++ b/tests/fixtures/invalid-schemas/draft-06.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "id": "http://jsonschema.net",
+  "type": "any",
+  "properties": {
+    "title": {
+      "id": "http://jsonschema.net/title",
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/tests/fixtures/invalid-schemas/draft-07.json
+++ b/tests/fixtures/invalid-schemas/draft-07.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "http://jsonschema.net",
+  "type": "any",
+  "properties": {
+    "title": {
+      "id": "http://jsonschema.net/title",
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/tests/fixtures/invalid-schemas/draft-201909.json
+++ b/tests/fixtures/invalid-schemas/draft-201909.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "id": "http://jsonschema.net",
+  "type": "any",
+  "properties": {
+    "title": {
+      "id": "http://jsonschema.net/title",
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/tests/fixtures/invalid-schemas/draft-202012.json
+++ b/tests/fixtures/invalid-schemas/draft-202012.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://jsoneditoronline.org/friends.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Friends",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "The friend's name."
+      },
+      "age": {
+        "description": "Age in years which must be equal to or greater than zero.",
+        "type": "integer",
+        "minimum": 0
+      },
+      "email": {
+        "type": "string",
+        "format": "email",
+        "description": "Optional email address of the friend.",
+        "required": true
+      }
+    },
+    "required": ["name", "age"]
+  }
+}

--- a/tests/fixtures/invalid-schemas/without-schema-entry.json
+++ b/tests/fixtures/invalid-schemas/without-schema-entry.json
@@ -1,0 +1,13 @@
+{
+  "id": "http://jsonschema.net",
+  "type": "object",
+  "properties": {
+    "title": {
+      "id": "http://jsonschema.net/title",
+      "type": "string"
+    }
+  },
+  "required": [
+    "title"
+  ]
+}

--- a/tests/fixtures/valid-schemas/draft-03.json
+++ b/tests/fixtures/valid-schemas/draft-03.json
@@ -1,0 +1,143 @@
+{
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "id": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+    "properties": {
+        "type": {
+            "type": [ "string", "array" ],
+            "items": {
+                "type": [ "string", { "$ref": "#" } ]
+            },
+            "uniqueItems": true,
+            "default": "any"
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "additionalProperties": {
+            "type": [ { "$ref": "#" }, "boolean" ],
+            "default": {}
+        },
+        "items": {
+            "type": [ { "$ref": "#" }, "array" ],
+            "items": { "$ref": "#" },
+            "default": {}
+        },
+        "additionalItems": {
+            "type": [ { "$ref": "#" }, "boolean" ],
+            "default": {}
+        },
+        "required": {
+            "type": "boolean",
+            "default": false
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "type": [ "string", "array", { "$ref": "#" } ],
+                "items": {
+                    "type": "string"
+                }
+            },
+            "default": {}
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minItems": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+        },
+        "maxItems": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "minLength": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+        },
+        "maxLength": {
+            "type": "integer"
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "default": {
+            "type": "any"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "format": {
+            "type": "string"
+        },
+        "divisibleBy": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true,
+            "default": 1
+        },
+        "disallow": {
+            "type": [ "string", "array" ],
+            "items": {
+                "type": [ "string", { "$ref": "#" } ]
+            },
+            "uniqueItems": true
+        },
+        "extends": {
+            "type": [ { "$ref": "#" }, "array" ],
+            "items": { "$ref": "#" },
+            "default": {}
+        },
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        }
+    },
+    "dependencies": {
+        "exclusiveMinimum": "minimum",
+        "exclusiveMaximum": "maximum"
+    },
+    "default": {}
+}

--- a/tests/fixtures/valid-schemas/draft-04.json
+++ b/tests/fixtures/valid-schemas/draft-04.json
@@ -1,0 +1,155 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Modified JSON Schema draft v4 that includes the optional '$ref' and 'format'",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string"
+        },
+        "format": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": { },
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": { }
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": { }
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": { }
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": { }
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": { }
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": { }
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": { }
+}

--- a/tests/fixtures/valid-schemas/draft-06.json
+++ b/tests/fixtures/valid-schemas/draft-06.json
@@ -1,0 +1,150 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "http://json-schema.org/draft-06/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "allOf": [
+                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "default": 0 }
+            ]
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": { "$ref": "#" },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "contains": { "$ref": "#" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": { "$ref": "#" },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "propertyNames": { "$ref": "#" },
+        "const": {},
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "default": {}
+}

--- a/tests/fixtures/valid-schemas/draft-07.json
+++ b/tests/fixtures/valid-schemas/draft-07.json
@@ -1,0 +1,168 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://json-schema.org/draft-07/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "allOf": [
+                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "default": 0 }
+            ]
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": { "$ref": "#" },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": true
+        },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "contains": { "$ref": "#" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": { "$ref": "#" },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "propertyNames": { "$ref": "#" },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true,
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "contentMediaType": { "type": "string" },
+        "contentEncoding": { "type": "string" },
+        "if": {"$ref": "#"},
+        "then": {"$ref": "#"},
+        "else": {"$ref": "#"},
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "default": true
+}

--- a/tests/fixtures/valid-schemas/draft-201909.json
+++ b/tests/fixtures/valid-schemas/draft-201909.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/core": true,
+        "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-09/vocab/validation": true,
+        "https://json-schema.org/draft/2019-09/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-09/vocab/format": false,
+        "https://json-schema.org/draft/2019-09/vocab/content": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Core and Validation specifications meta-schema",
+    "allOf": [
+        {"$ref": "meta/core"},
+        {"$ref": "meta/applicator"},
+        {"$ref": "meta/validation"},
+        {"$ref": "meta/meta-data"},
+        {"$ref": "meta/format"},
+        {"$ref": "meta/content"}
+    ],
+    "type": ["object", "boolean"],
+    "properties": {
+        "definitions": {
+            "$comment": "While no longer an official keyword as it is replaced by $defs, this keyword is retained in the meta-schema to prevent incompatible extensions as it remains in common use.",
+            "type": "object",
+            "additionalProperties": { "$recursiveRef": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "$comment": "\"dependencies\" is no longer a keyword, but schema authors should avoid redefining it to facilitate a smooth transition to \"dependentSchemas\" and \"dependentRequired\"",
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$recursiveRef": "#" },
+                    { "$ref": "meta/validation#/$defs/stringArray" }
+                ]
+            }
+        }
+    }
+}

--- a/tests/fixtures/valid-schemas/draft-202012.json
+++ b/tests/fixtures/valid-schemas/draft-202012.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://json-schema.org/draft/2020-12/schema",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+    "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+    "https://json-schema.org/draft/2020-12/vocab/content": true
+  },
+  "$dynamicAnchor": "meta",
+
+  "title": "Core and Validation specifications meta-schema",
+  "allOf": [
+    {"$ref": "meta/core"},
+    {"$ref": "meta/applicator"},
+    {"$ref": "meta/unevaluated"},
+    {"$ref": "meta/validation"},
+    {"$ref": "meta/meta-data"},
+    {"$ref": "meta/format-annotation"},
+    {"$ref": "meta/content"}
+  ],
+  "type": ["object", "boolean"],
+  "$comment": "This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.",
+  "properties": {
+    "definitions": {
+      "$comment": "\"definitions\" has been replaced by \"$defs\".",
+      "type": "object",
+      "additionalProperties": {"$dynamicRef": "#meta"},
+      "deprecated": true,
+      "default": {}
+    },
+    "dependencies": {
+      "$comment": "\"dependencies\" has been split and replaced by \"dependentSchemas\" and \"dependentRequired\" in order to serve their differing semantics.",
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [{"$dynamicRef": "#meta"}, {"$ref": "meta/validation#/$defs/stringArray"}]
+      },
+      "deprecated": true,
+      "default": {}
+    },
+    "$recursiveAnchor": {
+      "$comment": "\"$recursiveAnchor\" has been replaced by \"$dynamicAnchor\".",
+      "$ref": "meta/core#/$defs/anchorString",
+      "deprecated": true
+    },
+    "$recursiveRef": {
+      "$comment": "\"$recursiveRef\" has been replaced by \"$dynamicRef\".",
+      "$ref": "meta/core#/$defs/uriReferenceString",
+      "deprecated": true
+    }
+  }
+}


### PR DESCRIPTION
## Describe your changes

json-schema validation based on "$schema" json-entry

- Draft7Validator
- Draft6Validator
- Draft4Validator
- Draft3Validator
- Draft201909Validator
- Draft202012Validator

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] All tests passed on development environment
- [x] Linked card form board to PR (if applicable)
- [x] Applied proper tags to PR
- [x] Assigned PR for review

## Test scenarios if applicable
